### PR TITLE
Update to Triton V2.11

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,4 +1,4 @@
-ARG SERVERBASE=20.09-py3
+ARG SERVERBASE=21.06-py3
 
 FROM nvcr.io/nvidia/pytorch:${SERVERBASE} AS builder
 
@@ -10,7 +10,7 @@ RUN git clone https://github.com/rusty1s/pytorch_cluster.git
 RUN pushd pytorch_cluster &&\
     pip install . &&\
     mkdir build && pushd build &&\
-    cmake -DCMAKE_PREFIX_PATH=/opt/conda/lib/python3.6/site-packages/torch -DWITH_CUDA=${LIB_WITH_CUDA} .. &&\
+    cmake -DCMAKE_PREFIX_PATH=/opt/conda/lib/python3.8/site-packages/torch -DWITH_CUDA=${LIB_WITH_CUDA} .. &&\
     make -j ${NPROC} && mv *.so /workspace/ && popd &&\
     popd
 
@@ -18,7 +18,7 @@ RUN git clone https://github.com/rusty1s/pytorch_scatter.git
 RUN pushd pytorch_scatter &&\
     pip install . &&\
     mkdir build && pushd build &&\
-    cmake -DCMAKE_PREFIX_PATH=/opt/conda/lib/python3.6/site-packages/torch -DWITH_CUDA=${LIB_WITH_CUDA} .. &&\
+    cmake -DCMAKE_PREFIX_PATH=/opt/conda/lib/python3.8/site-packages/torch -DWITH_CUDA=${LIB_WITH_CUDA} .. &&\
     make -j ${NPROC} && mv *.so /workspace/ && popd &&\
     popd
 
@@ -26,7 +26,7 @@ RUN git clone https://github.com/rusty1s/pytorch_spline_conv.git
 RUN pushd pytorch_spline_conv &&\
     pip install . &&\
     mkdir build && pushd build &&\
-    cmake -DCMAKE_PREFIX_PATH=/opt/conda/lib/python3.6/site-packages/torch -DWITH_CUDA=${LIB_WITH_CUDA} .. &&\
+    cmake -DCMAKE_PREFIX_PATH=/opt/conda/lib/python3.8/site-packages/torch -DWITH_CUDA=${LIB_WITH_CUDA} .. &&\
     make -j ${NPROC} && mv *.so /workspace/ && popd &&\
     popd
 
@@ -34,7 +34,7 @@ RUN git clone https://github.com/rusty1s/pytorch_sparse.git
 RUN pushd pytorch_sparse &&\
     pip install . &&\
     mkdir build && pushd build &&\
-    cmake -DCMAKE_PREFIX_PATH=/opt/conda/lib/python3.6/site-packages/torch -DWITH_CUDA=${LIB_WITH_CUDA} .. &&\
+    cmake -DCMAKE_PREFIX_PATH=/opt/conda/lib/python3.8/site-packages/torch -DWITH_CUDA=${LIB_WITH_CUDA} .. &&\
     make -j ${NPROC} && mv *.so /workspace/ && popd &&\
     popd
 

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -39,8 +39,6 @@ RUN pushd pytorch_sparse &&\
     popd
 
 RUN git clone https://github.com/rusty1s/pytorch_geometric.git
-
-RUN pip install llvmlite --ignore-installed
 RUN pushd pytorch_geometric && pip install -e . && popd
 
 RUN pushd pytorch_geometric/examples/jit &&\
@@ -50,7 +48,7 @@ RUN pushd pytorch_geometric/examples/jit &&\
 
 FROM nvcr.io/nvidia/tritonserver:${SERVERBASE}
 
-ENV LD_LIBRARY_PATH="/opt/tritonserver/lib/pytorch:/usr/local/cuda/compat/lib:/usr/local/nvidia/lib:/usr/local/nvidia/lib64"
+ENV LD_LIBRARY_PATH="/opt/tritonserver/backends/pytorch:/usr/local/cuda/compat/lib:/usr/local/nvidia/lib:/usr/local/nvidia/lib64"
 ENV LD_PRELOAD="/torch_geometric/lib/libtorchscatter.so /torch_geometric/lib/libtorchsparse.so /torch_geometric/lib/libtorchcluster.so /torch_geometric/lib/libtorchsplineconv.so"
 
 RUN mkdir -p /run/shm

--- a/Dockerfile.buildonly
+++ b/Dockerfile.buildonly
@@ -39,7 +39,7 @@ RUN pushd pytorch_geometric && pip install -e . && popd
 
 FROM nvcr.io/nvidia/tritonserver:${SERVERBASE}
 
-ENV LD_LIBRARY_PATH="/opt/tritonserver/lib/pytorch:/usr/local/cuda/compat/lib:/usr/local/nvidia/lib:/usr/local/nvidia/lib64"
+ENV LD_LIBRARY_PATH="/opt/tritonserver/backends/pytorch:/usr/local/cuda/compat/lib:/usr/local/nvidia/lib:/usr/local/nvidia/lib64"
 ENV LD_PRELOAD="/torch_geometric/lib/libtorchscatter.so /torch_geometric/lib/libtorchsparse.so /torch_geometric/lib/libtorchcluster.so /torch_geometric/lib/libtorchsplineconv.so"
 
 RUN mkdir -p /run/shm

--- a/Dockerfile.buildonly
+++ b/Dockerfile.buildonly
@@ -1,0 +1,54 @@
+ARG SERVERBASE=21.06-py3
+
+FROM nvcr.io/nvidia/pytorch:${SERVERBASE} AS builder
+
+ENV FORCE_CUDA=1
+ARG LIB_WITH_CUDA=ON
+ARG NPROC=4
+
+RUN git clone https://github.com/rusty1s/pytorch_cluster.git
+RUN pushd pytorch_cluster &&\
+    mkdir build && pushd build &&\
+    cmake -DCMAKE_PREFIX_PATH=/opt/conda/lib/python3.8/site-packages/torch -DWITH_CUDA=${LIB_WITH_CUDA} .. &&\
+    make -j ${NPROC} && mv *.so /workspace/ && popd &&\
+    popd
+
+RUN git clone https://github.com/rusty1s/pytorch_scatter.git
+RUN pushd pytorch_scatter &&\
+    mkdir build && pushd build &&\
+    cmake -DCMAKE_PREFIX_PATH=/opt/conda/lib/python3.8/site-packages/torch -DWITH_CUDA=${LIB_WITH_CUDA} .. &&\
+    make -j ${NPROC} && mv *.so /workspace/ && popd &&\
+    popd
+
+RUN git clone https://github.com/rusty1s/pytorch_spline_conv.git
+RUN pushd pytorch_spline_conv &&\
+    mkdir build && pushd build &&\
+    cmake -DCMAKE_PREFIX_PATH=/opt/conda/lib/python3.8/site-packages/torch -DWITH_CUDA=${LIB_WITH_CUDA} .. &&\
+    make -j ${NPROC} && mv *.so /workspace/ && popd &&\
+    popd
+
+RUN git clone https://github.com/rusty1s/pytorch_sparse.git -b 0.6.10
+RUN pushd pytorch_sparse &&\
+    mkdir build && pushd build &&\
+    cmake -DCMAKE_PREFIX_PATH=/opt/conda/lib/python3.8/site-packages/torch -DWITH_CUDA=${LIB_WITH_CUDA} .. &&\
+    make -j ${NPROC} && mv *.so /workspace/ && popd &&\
+    popd
+
+RUN git clone https://github.com/rusty1s/pytorch_geometric.git
+RUN pushd pytorch_geometric && pip install -e . && popd
+
+FROM nvcr.io/nvidia/tritonserver:${SERVERBASE}
+
+ENV LD_LIBRARY_PATH="/opt/tritonserver/lib/pytorch:/usr/local/cuda/compat/lib:/usr/local/nvidia/lib:/usr/local/nvidia/lib64"
+ENV LD_PRELOAD="/torch_geometric/lib/libtorchscatter.so /torch_geometric/lib/libtorchsparse.so /torch_geometric/lib/libtorchcluster.so /torch_geometric/lib/libtorchsplineconv.so"
+
+RUN mkdir -p /run/shm
+RUN mkdir -p /models
+
+RUN mkdir -p /torch_geometric/lib
+RUN mkdir -p /torch_geometric/examples/
+
+COPY --from=builder /workspace/libtorchscatter.so /torch_geometric/lib/
+COPY --from=builder /workspace/libtorchsparse.so /torch_geometric/lib/
+COPY --from=builder /workspace/libtorchcluster.so /torch_geometric/lib/
+COPY --from=builder /workspace/libtorchsplineconv.so /torch_geometric/lib/

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -1,4 +1,4 @@
-ARG SERVERBASE=20.09-py3
+ARG SERVERBASE=21.06-py3
 
 FROM nvcr.io/nvidia/pytorch:${SERVERBASE} AS builder
 
@@ -8,7 +8,7 @@ RUN git clone https://github.com/rusty1s/pytorch_cluster.git
 RUN pushd pytorch_cluster &&\
     pip install . &&\
     mkdir build && pushd build &&\
-    cmake -DCMAKE_PREFIX_PATH=/opt/conda/lib/python3.6/site-packages/torch -DWITH_CUDA=${LIB_WITH_CUDA} .. &&\
+    cmake -DCMAKE_PREFIX_PATH=/opt/conda/lib/python3.8/site-packages/torch -DWITH_CUDA=${LIB_WITH_CUDA} .. &&\
     make -j $(nproc) && mv *.so /workspace/ && popd &&\
     popd
 
@@ -16,7 +16,7 @@ RUN git clone https://github.com/rusty1s/pytorch_scatter.git
 RUN pushd pytorch_scatter &&\
     pip install . &&\
     mkdir build && pushd build &&\
-    cmake -DCMAKE_PREFIX_PATH=/opt/conda/lib/python3.6/site-packages/torch -DWITH_CUDA=${LIB_WITH_CUDA} .. &&\
+    cmake -DCMAKE_PREFIX_PATH=/opt/conda/lib/python3.8/site-packages/torch -DWITH_CUDA=${LIB_WITH_CUDA} .. &&\
     make -j $(nproc) && mv *.so /workspace/ && popd &&\
     popd
 
@@ -24,7 +24,7 @@ RUN git clone https://github.com/rusty1s/pytorch_spline_conv.git
 RUN pushd pytorch_spline_conv &&\
     pip install . &&\
     mkdir build && pushd build &&\
-    cmake -DCMAKE_PREFIX_PATH=/opt/conda/lib/python3.6/site-packages/torch -DWITH_CUDA=${LIB_WITH_CUDA} .. &&\
+    cmake -DCMAKE_PREFIX_PATH=/opt/conda/lib/python3.8/site-packages/torch -DWITH_CUDA=${LIB_WITH_CUDA} .. &&\
     make -j $(nproc) && mv *.so /workspace/ && popd &&\
     popd
 
@@ -32,7 +32,7 @@ RUN git clone https://github.com/rusty1s/pytorch_sparse.git
 RUN pushd pytorch_sparse &&\
     pip install . &&\
     mkdir build && pushd build &&\
-    cmake -DCMAKE_PREFIX_PATH=/opt/conda/lib/python3.6/site-packages/torch -DWITH_CUDA=${LIB_WITH_CUDA} .. &&\
+    cmake -DCMAKE_PREFIX_PATH=/opt/conda/lib/python3.8/site-packages/torch -DWITH_CUDA=${LIB_WITH_CUDA} .. &&\
     make -j $(nproc) && mv *.so /workspace/ && popd &&\
     popd
 

--- a/triton-version.sh
+++ b/triton-version.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-export TRITON_VERSION="20.09-py3"
+export TRITON_VERSION="21.06-py3"
 


### PR DESCRIPTION
In addition to updating the version of the base images:
* newer python version
* backend library location moved
* separate buildonly Dockerfile added to build inference-only server image: just creates .so files for PyTorch addons, no `pip install .` or example GAT training